### PR TITLE
Updated padding for article carousel

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -320,6 +320,7 @@ hr {
     
     .blog-roll {
         grid-template-columns: repeat(2, 1fr);
+        padding-bottom: 2em;
     }
     
     .featured-article {


### PR DESCRIPTION
Article carousel was collapsing into footer at wider widths. Updated padding to give more space.